### PR TITLE
Fix lib64 installation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ Summary: the SSH library
 libssh2 is a library implementing the SSH2 protocol, available under the revised BSD license.
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/libssh2-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/libssh2-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/libssh2-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/libssh2-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/libssh2-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/libssh2-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/libssh2/badges/version.svg)](https://anaconda.org/conda-forge/libssh2)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/libssh2/badges/downloads.svg)](https://anaconda.org/conda-forge/libssh2)
+
 Installing libssh2
 ==================
 
@@ -32,7 +44,6 @@ It is possible to list all of the versions of `libssh2` available on your platfo
 ```
 conda search libssh2 --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -68,18 +79,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/libssh2-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/libssh2-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/libssh2-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/libssh2-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/libssh2-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/libssh2-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/libssh2/badges/version.svg)](https://anaconda.org/conda-forge/libssh2)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/libssh2/badges/downloads.svg)](https://anaconda.org/conda-forge/libssh2)
 
 
 Updating libssh2-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,11 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +16,35 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,24 +65,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,13 +2,8 @@
 
 mkdir build && cd build
 
-cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_SHARED_LIBS=OFF
+cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_LIBDIR=$PREFIX/lib
 cmake --build . --config Release --target install
 
-cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_SHARED_LIBS=ON
+cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_LIBDIR=$PREFIX/lib
 cmake --build . --config Release --target install
-
-if [ -d $PREFIX/lib64 ];then
-    rm -rf $PREFIX/lib64/pkgconfig
-    mv $PREFIX/lib64/* $PREFIX/lib
-fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   features:
       - vc9    # [win and py27]
       - vc10   # [win and py34]


### PR DESCRIPTION
This PR sets the installation directory to `$PREFIX/lib` (conda conventions) rather than to `$PREFIX/lib64` (GNU standard installation directories). Setting `CMAKE_INSTALL_LIBDIR` seems to do the trick. This way `pkgconfig` related files are consistent. Hopefully, this makes `libssh2` found correctly by cmake when building packages that depend on libssh2. Removing `pkgconfig` or moving/renaming installed directories manually causes cmake not to find libssh2. One example of such a failure to find libssh2 can be seen in [libgit2-feedstock](https://github.com/conda-forge/libgit2-feedstock/pull/8#issuecomment-270749175). 

[libssh2 can't be found by cmake](https://circleci.com/gh/shadowwalkersb/libgit2-feedstock/49?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).
```
-- Checking for module 'libssh2'
--   No package 'libssh2' found
-- LIBSSH2 not found. Set CMAKE_PREFIX_PATH if it is installed outside of the default search path.
```

xref: https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html