### PR TITLE
reset build number to 0 to avoid gap in build number sequence

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   features:
       - vc9    # [win and py27]
       - vc10   # [win and py34]


### PR DESCRIPTION
Closes #5 .