### PR TITLE
bump

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 088307d9f6b6c4b8c13f34602e8ff65d21c2dc4d55284dfe15d502c4ee190d67
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('libssh2') }}
 


### PR DESCRIPTION
OK, again, trying to solve https://github.com/conda-forge/netcdf4-feedstock/issues/78, I was able to get a working `netcdf4` locally after rebuilding `libssh2` &rarr; `curl` &rarr; `netcdf4`. If that is really the solution or if I was just protected from whatever was in AppVeyor will be clear only after I do the same in our CIs.