### PR TITLE
test no openssl on appveyor

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,11 +3,13 @@ set PATH=%PREFIX%\cmake-bin\bin;%PATH%
 mkdir build && cd build
 
 cmake -G "%CMAKE_GENERATOR%" ^
-		  -D BUILD_SHARED_LIBS=ON ^
-			-D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-			-D ENABLE_ZLIB_COMPRESSION=ON ^
-			-D CMAKE_BUILD_TYPE=Release ^
-			%SRC_DIR%
+	  -D CMAKE_BUILD_TYPE=Release ^
+	  -D BUILD_SHARED_LIBS=ON ^
+	  -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+	  -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+	  -D ENABLE_ZLIB_COMPRESSION=ON ^
+	  -D CMAKE_BUILD_TYPE=Release ^
+	%SRC_DIR%
 IF %ERRORLEVEL% NEQ 0 exit 1
 
 cmake --build . --config Release --target INSTALL

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,7 @@ fi
 mkdir build && cd build
 
 cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D CMAKE_PREFIX_PATH=$PREFIX \
       -D BUILD_SHARED_LIBS=OFF \
       -D CRYPTO_BACKEND=OpenSSL \
       -D CMAKE_INSTALL_LIBDIR=lib \
@@ -21,6 +22,7 @@ make -j${CPU_COUNT}
 make install
 
 cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D CMAKE_PREFIX_PATH=$PREFIX \
       -D BUILD_SHARED_LIBS=ON \
       -D CRYPTO_BACKEND=OpenSSL \
       -D CMAKE_INSTALL_LIBDIR=lib \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 088307d9f6b6c4b8c13f34602e8ff65d21c2dc4d55284dfe15d502c4ee190d67
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('libssh2') }}
 


### PR DESCRIPTION
~~Do not merge this yet. I'm just testing if we can build safely without AppVeyor's OpenSSL. The right solution should not remove something in the `bld.bat` file!~~

---
Edit: this uses cmake options to avoid linking with AppVeyor's openssl.