### PR TITLE
Win: Export the correct symbols

### DIFF
--- a/recipe/246c7cb0184b9e1a882c753b412825799c7a9118.patch
+++ b/recipe/246c7cb0184b9e1a882c753b412825799c7a9118.patch
@@ -1,0 +1,23 @@
+From 246c7cb0184b9e1a882c753b412825799c7a9118 Mon Sep 17 00:00:00 2001
+From: "Uwe L. Korn" <xhochy@users.noreply.github.com>
+Date: Sat, 16 May 2020 08:45:40 +0200
+Subject: [PATCH] Use libssh2_EXPORTS as an alternative to _WINDLL
+
+`_WINDLL` is only defined when a Visual Studio CMake generator is used, `libssh2_EXPORTS` is used though for all CMake generator if a shared libssh2 library is being built.
+---
+ include/libssh2.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/libssh2.h b/include/libssh2.h
+index 386bcc892..110e32ae2 100644
+--- a/include/libssh2.h
++++ b/include/libssh2.h
+@@ -100,7 +100,7 @@ extern "C" {
+ /* Allow alternate API prefix from CFLAGS or calling app */
+ #ifndef LIBSSH2_API
+ # ifdef LIBSSH2_WIN32
+-#  ifdef _WINDLL
++#  if defined(_WINDLL) || defined(libssh2_EXPORTS)
+ #   ifdef LIBSSH2_LIBRARY
+ #    define LIBSSH2_API __declspec(dllexport)
+ #   else

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,26 +5,6 @@ copy %RECIPE_DIR%\missing_files\*.c tests\
 
 set PATH=%PREFIX%\cmake-bin\bin;%PATH%
 
-mkdir build_static && cd build_static
-
-:: Build static libraries
-cmake -GNinja ^
-    -D CMAKE_BUILD_TYPE=Release ^
-    -D BUILD_SHARED_LIBS=OFF ^
-    -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-    -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
-    -D ENABLE_ZLIB_COMPRESSION=ON ^
-    -D BUILD_EXAMPLES=OFF ^
-    -D BUILD_TESTING=OFF ^
-	%SRC_DIR%
-IF %ERRORLEVEL% NEQ 0 exit 1
-
-ninja
-IF %ERRORLEVEL% NEQ 0 exit 1
-ninja install
-IF %ERRORLEVEL% NEQ 0 exit 1
-
-cd ..
 mkdir build_shared && cd build_shared
 
 :: Build shared libraries

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
     # merged into upstream in with small modification in:
     # https://github.com/libssh2/libssh2/pull/402
     - 0001-libssh2-1.9.0-CVE-2019-17498.patch
+    - 246c7cb0184b9e1a882c753b412825799c7a9118.patch
 
 build:
   number: 1


### PR DESCRIPTION
Also did some manual testing locally:

- libssh2 1.9-as-in-master with netcdf4: Fails.
- libssh2 1.9-in-this-PR in host and run of netcdf: Passes.
- libssh2 1.9-in-this-PR in host and 1.8 in run of netcdf: Passes.
- libssh2 1.8 in host (ignore_run_exports) and 1.9-in-this-PR run of netcdf: Passes.

The failing file exists tests was misleading us in adding a build for static libraries. 

Not sure why https://github.com/libssh2/libssh2/blob/f1b6fca89b2c3ca5ea0f47290ad7010d4381bbad/include/libssh2.h#L101-L115 is not used.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
